### PR TITLE
having origin '*' is invalid with AllowCredentials

### DIFF
--- a/middlewares.go
+++ b/middlewares.go
@@ -98,10 +98,13 @@ func Cors(cors CORS) Handle {
 			if !allowAll {
 				allowOrigin = strings.Join(cors.AllowOrigins, ",")
 			}
-			ctx.SetHeader("Access-Control-Allow-Origin", allowOrigin)
 			if cors.AllowCredentials {
+				if allowOrigin == "*" {
+					allowOrigin = currentOrigin
+				}
 				ctx.SetHeader("Access-Control-Allow-Credentials", "true")
 			}
+			ctx.SetHeader("Access-Control-Allow-Origin", allowOrigin)
 
 			if isPreflight {
 				ctx.SetHeader("Vary", "Access-Control-Request-Method")


### PR DESCRIPTION
This is the recommended approach for the error `has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'`.

It checks if the origin value will be `*` if allow credentials is true. If so, it uses the current origin instead of `*`.